### PR TITLE
add node 10 support, fix missing env variables in IFC

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,12 +54,13 @@ module.exports = createFunctions(config, services);
 
 The config object can contain the following values:
 
-| key               | required | default                                                                                            | type       | description                                                                                                                                              |
-| ----------------- | -------- | -------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| validatePrivilege | false    | (privilege) => (req, res, next) => next()                                                          | Function   | A function that accepts a privilege and returns an expressJs middleware function to validate wheter the client has the correct privilege for the request |
-| middleware        | false    | []                                                                                                 | Function[] | An array of expressJs middlewares to be added to all routes across all services                                                                          |
-| corsEnabled       | false    | true                                                                                               | boolean    | whether the expressJs cors middleware should be enabled https://www.npmjs.com/package/cors                                                               |
-| corsOptions       | false    | {origin: true,methods: "GET,PUT,POST,DELETE,OPTIONS", allowedHeaders: "token, role, content-type"} | Object     | expressJs cors middleware options https://www.npmjs.com/package/cors#configuring-cors                                                                    |
+| key               | required | default                                                                                            | type       | description                                                                                                                                               |
+| ----------------- | -------- | -------------------------------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| region            | false    | us-central1                                                                                        | string     | GCP region in which to deploy functions. Valid values are listed here: https://firebase.google.com/docs/functions/locations                               |
+| validatePrivilege | false    | (privilege) => (req, res, next) => next()                                                          | Function   | A function that accepts a privilege and returns an expressJs middleware function to validate whether the client has the correct privilege for the request |
+| middleware        | false    | []                                                                                                 | Function[] | An array of expressJs middleware to be added to all routes across all services                                                                            |
+| corsEnabled       | false    | true                                                                                               | boolean    | whether the expressJs cors middleware should be enabled https://www.npmjs.com/package/cors                                                                |
+| corsOptions       | false    | {origin: true,methods: "GET,PUT,POST,DELETE,OPTIONS", allowedHeaders: "token, role, content-type"} | Object     | expressJs cors middleware options https://www.npmjs.com/package/cors#configuring-cors                                                                     |
 
 #### Creating your first service
 
@@ -124,15 +125,14 @@ module.exports = [hello];
 
 #### Routes
 
-| key            | required | type              | description                                                                                                                                                                                                                                                |
-| -------------- | -------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| path           | true     | string            | expressJs style paths that can contain parameters                                                                                                                                                                                                          |
-| method         | true     | string            | ['get', 'post', 'put', 'delete']                                                                                                                                                                                                                           |
-| function       | false    | function          | to be executed when a request reaches the defined `path`(optional if privilege defines functions)                                                                                                                                                          |
-| privilege      | false    | string            | one of the privileges defined in validatePrivilege middleware                                                                                                                                                                                              |
-| ignoreBody     | false    | boolean           | if set to true the body of POST / PUT requests to the route will not be checked against the service schema                                                                                                                                                 |
-| middleware     | false    | Array<Middleware> | an array of middleware that will apply to this route                                                                                                                                                                                                       |
-| runtimeOptions | false    | object            | An object containing 2 optional properties. `memory`: amount of memory to allocate to the function, possible values are: '128MB', '256MB', '512MB', '1GB', and '2GB'. `timeoutSeconds`: timeout for the function in seconds, possible values are 0 to 540. |  |
+| key        | required | type              | description                                                                                                |
+| ---------- | -------- | ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| path       | true     | string            | expressJs style paths that can contain parameters                                                          |
+| method     | true     | string            | ['get', 'post', 'put', 'delete']                                                                           |
+| function   | false    | function          | to be executed when a request reaches the defined `path`(optional if privilege defines functions)          |
+| privilege  | false    | string            | one of the privileges defined in validatePrivilege middleware                                              |
+| ignoreBody | false    | boolean           | if set to true the body of POST / PUT requests to the route will not be checked against the service schema |
+| middleware | false    | Array<Middleware> | an array of middleware that will apply to this route                                                       |
 
 #### Events
 

--- a/src/configStore.js
+++ b/src/configStore.js
@@ -1,0 +1,17 @@
+const defaultCorsOptions = {
+  origin: true,
+  methods: 'GET,PUT,POST,DELETE,OPTIONS',
+  allowedHeaders: 'token, role, content-type',
+};
+
+const defaultValidatePrivilege = _privilege => (_req, _res, next) => next();
+
+const defaultConfig = {
+  region: 'us-central1',
+  validatePrivilege: defaultValidatePrivilege,
+  middleware: [],
+  corsEnabled: true,
+  corsOptions: defaultCorsOptions,
+};
+
+module.exports.config = defaultConfig;

--- a/src/iFC.js
+++ b/src/iFC.js
@@ -39,8 +39,6 @@ async function ifc(service, options = defaultOptions, req = {}) {
     FUNCTIONS_EMULATOR === 'true' ||
     IS_FIREBASE_CLI === 'true';
 
-  console.log('ifc -> isLocalhost', isLocalhost);
-
   const port = process.env.PORT || 5000;
 
   const { headers: { host = `localhost:${port}`, ...reqHeaders } = {} } = req;
@@ -51,9 +49,6 @@ async function ifc(service, options = defaultOptions, req = {}) {
   const cloudResourceLocation = isLocalhost
     ? firebaseConfig.cloudResourceLocation || region
     : X_GOOGLE_FUNCTION_REGION || region;
-
-  console.log('ifc -> projectId', projectId);
-  console.log('ifc -> cloudResourceLocation', cloudResourceLocation);
 
   const reqUrl = isLocalhost
     ? `http://${host}/${projectId}/${cloudResourceLocation}1`

--- a/src/iFC.js
+++ b/src/iFC.js
@@ -1,8 +1,9 @@
 const axios = require('axios');
+const configStore = require('./configStore');
 
 const defaultOptions = {
   url: '',
-  headers: {}
+  headers: {},
 };
 
 /**
@@ -20,24 +21,43 @@ const defaultOptions = {
  *   used to pass through required prams including auth information to the remote service
  */
 async function ifc(service, options = defaultOptions, req = {}) {
-  const { X_GOOGLE_GCP_PROJECT, X_GOOGLE_FUNCTION_REGION } = process.env;
+  const {
+    X_GOOGLE_GCP_PROJECT,
+    X_GOOGLE_FUNCTION_REGION,
+    NODE_ENV,
+    FIREBASE_CONFIG,
+    FUNCTIONS_EMULATOR,
+    IS_FIREBASE_CLI,
+  } = process.env;
+  const firebaseConfig =
+    typeof FIREBASE_CONFIG === 'string' ? JSON.parse(FIREBASE_CONFIG) : {};
 
-  const isLocalhost = !X_GOOGLE_FUNCTION_REGION;
+  const { region } = configStore.config;
+
+  const isLocalhost =
+    NODE_ENV !== 'production' ||
+    FUNCTIONS_EMULATOR === 'true' ||
+    IS_FIREBASE_CLI === 'true';
+
+  console.log('ifc -> isLocalhost', isLocalhost);
 
   const port = process.env.PORT || 5000;
 
   const { headers: { host = `localhost:${port}`, ...reqHeaders } = {} } = req;
 
   const projectId = isLocalhost
-    ? JSON.parse(process.env.FIREBASE_CONFIG).projectId
-    : null;
+    ? firebaseConfig.projectId
+    : X_GOOGLE_GCP_PROJECT || firebaseConfig.projectId;
   const cloudResourceLocation = isLocalhost
-    ? JSON.parse(process.env.FIREBASE_CONFIG).cloudResourceLocation
-    : null;
+    ? firebaseConfig.cloudResourceLocation || region
+    : X_GOOGLE_FUNCTION_REGION || region;
+
+  console.log('ifc -> projectId', projectId);
+  console.log('ifc -> cloudResourceLocation', cloudResourceLocation);
 
   const reqUrl = isLocalhost
     ? `http://${host}/${projectId}/${cloudResourceLocation}1`
-    : `https://${X_GOOGLE_FUNCTION_REGION}-${X_GOOGLE_GCP_PROJECT}.cloudfunctions.net`;
+    : `https://${cloudResourceLocation}-${projectId}.cloudfunctions.net`;
 
   const { url, headers = {}, ...otherOptions } = options;
 
@@ -45,9 +65,9 @@ async function ifc(service, options = defaultOptions, req = {}) {
     url: `${reqUrl}/${service}/${url}`,
     headers: {
       ...reqHeaders,
-      ...headers
+      ...headers,
     },
-    ...otherOptions
+    ...otherOptions,
   });
 }
 

--- a/src/parseRoutes.js
+++ b/src/parseRoutes.js
@@ -5,21 +5,8 @@ const validateFields = require('./validateFields');
 const setDefaults = require('./validateFields/setDefaults').middleware;
 const applyModifiers = require('./validateFields/applyModifiers').middleware;
 
-const defaultCorsOptions = {
-  origin: true,
-  methods: 'GET,PUT,POST,DELETE,OPTIONS',
-  allowedHeaders: 'token, role, content-type'
-};
-
-const defaultValidatePrivilege = _privilege => (_req, _res, next) => next();
-
 module.exports = (
-  {
-    validatePrivilege = defaultValidatePrivilege,
-    middleware = [],
-    corsEnabled = true,
-    corsOptions = defaultCorsOptions
-  },
+  { validatePrivilege, middleware, corsEnabled, corsOptions },
   service
 ) => {
   const {
@@ -27,7 +14,7 @@ module.exports = (
     schema,
     postSchema = null,
     middleware: serviceMiddleware = [],
-    keepAlive = false
+    keepAlive = false,
   } = service;
 
   const app = express();
@@ -54,7 +41,7 @@ module.exports = (
       privilege = 'any',
       ignoreBody = false,
       schema: routeSchema = null,
-      middleware: routeMiddleware = []
+      middleware: routeMiddleware = [],
     }) => {
       if (ignoreBody) {
         app[method](
@@ -112,10 +99,7 @@ const withResponse = handler => async (req, res) => {
 
     const [status, message, headers = {}] = result;
 
-    return res
-      .status(status)
-      .set(headers)
-      .send(message);
+    return res.status(status).set(headers).send(message);
   } catch (error) {
     console.error(error);
     return res


### PR DESCRIPTION
The node 10 runtime for firebase functions is missing ENV variables that the iFC required. deriving the values from either the old variables or the new ones adds support for node 10.
One variable that can no longer be derived if function region. To fix this we now require the region to be set and we can read that value to derive the region. The default region is 'us-central1'.