### PR TITLE
bump version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-framework",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A framework designed to increase productivity in serverless applications using firebase",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
the beta 1.1.0 version was published as a beta tag but without a suffix. This necessitated bumping the version to publish as latest.