### PR TITLE
Feat: add defines schema with object type

### DIFF
--- a/src/validateSchema/index.js
+++ b/src/validateSchema/index.js
@@ -106,6 +106,10 @@ function validate(schema, basePath, customName = null) {
           }
         },
       );
+
+      if (typeof config.type === 'object' && typeof config.childSchema !== 'undefined') {
+        validate(config.childSchema, basePath, customName);
+      }
     });
 
     return `${basePath}: ${customName ||

--- a/src/validateSchema/rules.js
+++ b/src/validateSchema/rules.js
@@ -38,6 +38,10 @@ module.exports = {
     writeModifier: {
       required: false,
       type: "function"
+    },
+    childSchema: {
+      required: false,
+      type: "object"
     }
   }
 };


### PR DESCRIPTION
- To validate the values in a schema of type `object`, I created an additional type called `childSchema`, which defines the child schemas.

- Call the validate function again within validateFields to perform the checks.

- Refactor code 