### PR TITLE
fix(v2): iFC func waits for more data that never arrives if the content-length from the request is reused 

### DIFF
--- a/src/iFC.js
+++ b/src/iFC.js
@@ -41,7 +41,7 @@ async function ifc(service, options = defaultOptions, req = {}) {
 
   const port = process.env.PORT || 5000;
 
-  const { headers: { host = `localhost:${port}`, ...reqHeaders } = {} } = req;
+  const { headers: { host = `localhost:${port}`,'content-length': contentLength, ...reqHeaders } = {} } = req;
 
   const projectId = isLocalhost
     ? firebaseConfig.projectId


### PR DESCRIPTION
## Why?
 When using Node.js 20 on Cloud Function v2, it seems that content-length is not automatically removed in axios@v1.6.7. This causes the server to keep waiting if the content-length in the header is larger than the actual length of the body.

I haven't found any documentation about this yet, but removing content-length makes it work properly.